### PR TITLE
Version bumps for circe, akka and jawn

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,29 +1,33 @@
+lazy val versions = new {
+  val circe   = "0.5.0"
+  val akka    = "2.4.9"
+  val jawn    = "0.9.0"
+  val specs2  = "3.7.2"
+}
+
 lazy val `stream-json` = project settings (
   libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-stream" % "2.4.2" % "provided",
-    "org.spire-math"    %% "jawn-parser" % "0.8.4"))
+    "com.typesafe.akka" %% "akka-stream" % versions.akka % "provided",
+    "org.spire-math"    %% "jawn-parser" % versions.jawn))
 
 lazy val `http-json` = project dependsOn `stream-json` settings (
-  libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % "2.4.2" % "provided")
+  libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % versions.akka % "provided")
 
 lazy val tests = project dependsOn (`stream-json`, `http-json`, `stream-circe`, `http-circe`) settings (
   dontRelease,
   libraryDependencies ++= List(
-      "com.typesafe.akka" %% "akka-http-experimental" % "2.4.2" % "test",
-      "org.specs2"        %% "specs2-core"            % "3.7.2" % "test",
-      "io.circe"          %% "circe-generic"          % "0.3.0" % "test"))
+      "com.typesafe.akka" %% "akka-http-experimental" % versions.akka % "test",
+      "org.specs2"        %% "specs2-core"            % versions.specs2 % "test",
+      "io.circe"          %% "circe-generic"          % versions.circe % "test"))
 lazy val parent = project in file(".") dependsOn (`http-json`, `http-circe`) aggregate (`stream-json`, `http-json`, `stream-circe`, `http-circe`, tests) settings parentSettings(dontRelease)
 
 // circe support
 lazy val `stream-circe` = project in file("support")/"stream-circe" dependsOn `stream-json` settings (
   libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-stream" % "2.4.2" % "provided",
-    "io.circe"          %% "circe-jawn"  % "0.3.0"))
+    "com.typesafe.akka" %% "akka-stream" % versions.akka % "provided",
+    "io.circe"          %% "circe-jawn"  % versions.circe))
 
 lazy val `http-circe` = project in file("support")/"http-circe" dependsOn (`stream-circe`, `http-json`) settings (
-  libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % "2.4.2" % "provided")
-
-
-
+  libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % versions.akka % "provided")
 
 addCommandAlias("travis", ";clean;coverage;testOnly -- timefactor 3;coverageReport;coverageAggregate")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -30,7 +30,7 @@ object Build extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
            git.baseVersion := "3.0.0",
-               projectName := "akka",
+               projectName := "akka-stream-json",
               organization := "de.knutwalker",
                description := "Json support for Akka Streams/Http via Jawn",
                 maintainer := "Paul Horn",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.13"
-addSbtPlugin("de.knutwalker" % "sbt-knutwalker" % "0.3.6")
+addSbtPlugin("de.knutwalker" % "sbt-knutwalker" % "0.4.1")
 addSbtPlugin("me.lessis"     % "bintray-sbt"    % "0.3.0")


### PR DESCRIPTION
Renamed project to akka-stream-json
Extracted lib versions
Bumped versions of
- circe 0.5.0
- akka 2.5.9
- jawn 0.9.0
- sbt 0.13.12
- sbt-knutwalker 0.4.1
