### PR TITLE
Bump Circe + Akka-http + Scala 2.12 Support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,9 @@
 lazy val versions = new {
-  val circe   = "0.5.0"
-  val akka    = "2.4.9"
-  val jawn    = "0.9.0"
-  val specs2  = "3.7.2"
+  val circe      = "0.7.0"
+  val akkaHttp   = "10.0.4"
+  val akka       = "2.4.17"
+  val jawn       = "0.10.4"
+  val specs2     = "3.8.6"
 }
 
 lazy val `stream-json` = project settings (
@@ -11,12 +12,12 @@ lazy val `stream-json` = project settings (
     "org.spire-math"    %% "jawn-parser" % versions.jawn))
 
 lazy val `http-json` = project dependsOn `stream-json` settings (
-  libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % versions.akka % "provided")
+  libraryDependencies += "com.typesafe.akka" %% "akka-http" % versions.akkaHttp % "provided")
 
 lazy val tests = project dependsOn (`stream-json`, `http-json`, `stream-circe`, `http-circe`) settings (
   dontRelease,
   libraryDependencies ++= List(
-      "com.typesafe.akka" %% "akka-http-experimental" % versions.akka % "test",
+      "com.typesafe.akka" %% "akka-http" % versions.akkaHttp % "test",
       "org.specs2"        %% "specs2-core"            % versions.specs2 % "test",
       "io.circe"          %% "circe-generic"          % versions.circe % "test"))
 lazy val parent = project in file(".") dependsOn (`http-json`, `http-circe`) aggregate (`stream-json`, `http-json`, `stream-circe`, `http-circe`, tests) settings parentSettings(dontRelease)
@@ -28,6 +29,6 @@ lazy val `stream-circe` = project in file("support")/"stream-circe" dependsOn `s
     "io.circe"          %% "circe-jawn"  % versions.circe))
 
 lazy val `http-circe` = project in file("support")/"http-circe" dependsOn (`stream-circe`, `http-json`) settings (
-  libraryDependencies += "com.typesafe.akka" %% "akka-http-experimental" % versions.akka % "provided")
+  libraryDependencies += "com.typesafe.akka" %% "akka-http" % versions.akkaHttp % "provided")
 
 addCommandAlias("travis", ";clean;coverage;testOnly -- timefactor 3;coverageReport;coverageAggregate")

--- a/http-json/src/main/scala/de/knutwalker/akka/http/JsonSupport.scala
+++ b/http-json/src/main/scala/de/knutwalker/akka/http/JsonSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -28,6 +28,8 @@ object Build extends AutoPlugin {
   override def trigger = allRequirements
   override def requires = KSbtPlugin
 
+  val currentScalaVersion = "2.12.1"
+
   override lazy val projectSettings = Seq(
            git.baseVersion := "3.0.0",
                projectName := "akka", // see https://github.com/knutwalker/akka-stream-json/pull/4#issuecomment-244199557 for why it's akka and not akka-stream-json
@@ -38,7 +40,8 @@ object Build extends AutoPlugin {
              githubProject := Github("knutwalker", "akka-stream-json"),
             bintrayPackage := "akka-stream-json",
                javaVersion := JavaVersion.Java18,
-              scalaVersion := "2.11.8",
+        crossScalaVersions := Seq("2.11.8", currentScalaVersion),
+              scalaVersion := currentScalaVersion,
   scalacOptions in Compile += "-Xexperimental",
                  publishTo := { if (git.gitCurrentTags.value.isEmpty) (publishTo in bt).value else publishTo.value }
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "1.7.13"
-addSbtPlugin("de.knutwalker" % "sbt-knutwalker" % "0.4.1")
+addSbtPlugin("de.knutwalker" % "sbt-knutwalker" % "0.5.1")
 addSbtPlugin("me.lessis"     % "bintray-sbt"    % "0.3.0")

--- a/stream-json/src/main/scala/de/knutwalker/akka/stream/JsonStreamParser.scala
+++ b/stream-json/src/main/scala/de/knutwalker/akka/stream/JsonStreamParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/http-circe/src/main/scala/de/knutwalker/akka/http/support/CirceHttpSupport.scala
+++ b/support/http-circe/src/main/scala/de/knutwalker/akka/http/support/CirceHttpSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/de/knutwalker/akka/http/JsonSupportSpec.scala
+++ b/tests/src/test/scala/de/knutwalker/akka/http/JsonSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2016 Paul Horn
+ * Copyright 2015 – 2017 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add support for Scala 2.12 (cross built against Scala 2.11 as well)
Bumped Circe to 0.7.0
Bumped Akka-Http to 10.0.4

Note that due to the changes in Circe 0.7.0, there will be much better performance when streaming the JSON, see https://github.com/circe/circe/releases/tag/v0.7.0-M1 for more info

@knutwalker I think you need to do the version bumping yourself, let me know when you publish