### PR TITLE
Throw proper exception instead of IllegalArgumentException

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ to get a `Source[A, _]`.
 This flow even supports parsing multiple json documents in whatever
 fragmentation they may arrive, which is great for consuming stream/sse based APIs.
 
+If there is an error in parsing the Json you can catch `de.knutwalker.akka.http.support.CirceStreamSupport.JsonParsingException`.
+The exception provides Circe cursor history, current cursor and the type hint of the error.
 
 ## Why jawn?
 

--- a/support/stream-circe/src/main/scala/de/knutwalker/akka/stream/support/CirceStreamSupport.scala
+++ b/support/stream-circe/src/main/scala/de/knutwalker/akka/stream/support/CirceStreamSupport.scala
@@ -41,11 +41,14 @@ trait CirceStreamSupport {
   def encode[A](implicit A: Encoder[A], P: Printer = Printer.noSpaces): Flow[A, String, NotUsed] =
     Flow[A].map(a ⇒ P.pretty(A(a)))
 
+  case class JsonParsingException(hist: List[CursorOp], cursor: HCursor, typeHint: String) extends Exception {
+    override def getMessage: String = errorMessage(hist, cursor, typeHint)}
+
   private[knutwalker] def decodeJson[A](json: Json)(implicit decoder: Decoder[A]): A = {
     val cursor = json.hcursor
     decoder(cursor) match {
       case Right(e) ⇒ e
-      case Left(f)  ⇒ throw new IllegalArgumentException(errorMessage(f.history, cursor, f.message))
+      case Left(f)  ⇒ throw JsonParsingException(f.history, cursor, f.message)
     }
   }
 


### PR DESCRIPTION
Instead of throwing an `IllegalArgumentException`, we should throw a proper exception which can be catched properly