### PR TITLE
Bump all of the major versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 lazy val versions = new {
-  val circe      = "0.8.0"
-  val akkaHttp   = "10.0.7"
-  val akka       = "2.4.17"
-  val jawn       = "0.10.4"
+  val circe      = "0.9.0"
+  val akkaHttp   = "10.0.11"
+  val akka       = "2.5.9"
+  val jawn       = "0.11.0"
   val specs2     = "3.8.6"
 }
 

--- a/http-json/src/main/scala/de/knutwalker/akka/http/JsonSupport.scala
+++ b/http-json/src/main/scala/de/knutwalker/akka/http/JsonSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 – 2018 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -40,7 +40,7 @@ object Build extends AutoPlugin {
              githubProject := Github("knutwalker", "akka-stream-json"),
             bintrayPackage := "akka-stream-json",
                javaVersion := JavaVersion.Java18,
-        crossScalaVersions := Seq("2.11.8", currentScalaVersion),
+        crossScalaVersions := Seq("2.11.11", currentScalaVersion),
               scalaVersion := currentScalaVersion,
   scalacOptions in Compile += "-Xexperimental",
                  publishTo := { if (git.gitCurrentTags.value.isEmpty) (publishTo in bt).value else publishTo.value }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.12
+sbt.version=0.13.16

--- a/stream-json/src/main/scala/de/knutwalker/akka/stream/JsonStreamParser.scala
+++ b/stream-json/src/main/scala/de/knutwalker/akka/stream/JsonStreamParser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 – 2018 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/http-circe/src/main/scala/de/knutwalker/akka/http/support/CirceHttpSupport.scala
+++ b/support/http-circe/src/main/scala/de/knutwalker/akka/http/support/CirceHttpSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 – 2018 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/support/stream-circe/src/main/scala/de/knutwalker/akka/stream/support/CirceStreamSupport.scala
+++ b/support/stream-circe/src/main/scala/de/knutwalker/akka/stream/support/CirceStreamSupport.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 – 2018 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/tests/src/test/scala/de/knutwalker/akka/http/JsonSupportSpec.scala
+++ b/tests/src/test/scala/de/knutwalker/akka/http/JsonSupportSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 – 2017 Paul Horn
+ * Copyright 2015 – 2018 Paul Horn
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Bumped Circe to 0.9.0
* Bumped Akka-Http to 10.0.11
* Bumped Jawn to 0.11.0
* Bumped Akka to 2.5.9

This PR bumps all of the dependencies to latest versions, we need this because we are migrating to Circe 0.9.0

@knutwalker Is it possible to release this as 3.5.0?